### PR TITLE
Improve the 'Parallel image pulls' documentation

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -354,9 +354,9 @@ If you are using Docker 1.9+, you may want to consider enabling parallel image p
 ----
 kubeletArguments:
   serialize-image-pulls:
-  - true <1>
+  - "false" <1>
 ----
-<1> Change to false to enable parallel pulls.
+<1> Change to true to disable parallel pulls. (This is the default config)
 ====
 
 [[passwords]]


### PR DESCRIPTION
This improves the 'Parallel Image Pulls' configuration, clarifying the default behaviour, changing the parameter to 'false' (that enables the described feature) and also adding 'quotes' on the selected behaviour (as this is a array of strings, not a boolean).